### PR TITLE
feat(config): Add in-memory config loading and validation

### DIFF
--- a/zn_report/config.py
+++ b/zn_report/config.py
@@ -14,6 +14,10 @@ from zn_report.constants import (
 )
 
 
+class ConfigurationError(ValueError):
+    """Custom exception for configuration errors."""
+
+
 @dataclass
 class Branding:
     """Branding configuration."""
@@ -31,6 +35,17 @@ class Palette:
     accent: str
     muted: str
     categorical: list[str]
+
+    def __post_init__(self):
+        """Validate palette configuration."""
+        if not (
+            self.categorical
+            and isinstance(self.categorical, list)
+            and all(isinstance(s, str) for s in self.categorical)
+        ):
+            raise ValueError(
+                "style.palette.categorical must be a non-empty list of strings"
+            )
 
 
 @dataclass
@@ -63,6 +78,11 @@ class Summary:
     enabled: bool = True
     provider: Provider = Provider.LOCAL
     max_chars: int = 700
+
+    def __post_init__(self):
+        """Validate summary configuration."""
+        if self.max_chars <= 0:
+            raise ValueError("summary.max_chars must be > 0")
 
 
 @dataclass
@@ -110,39 +130,31 @@ def deep_merge(base: dict, override: dict) -> dict:
 def coerce_config(d: dict) -> Config:
     """Convert a merged dict into typed dataclasses.
 
-    Raise ValueError on missing/invalid fields.
+    Raise ConfigurationError on missing/invalid fields.
     """
-    cfg = deepcopy(d)
+    # No deepcopy needed, as load_config provides a fresh dict.
+    cfg = d
 
-    # --- Validation and Coercion ---
+    # --- Main Coercion and Construction ---
     try:
-        summary_cfg = cfg["summary"]
-        provider_str = summary_cfg["provider"]
-        summary_cfg["provider"] = Summary.Provider(provider_str)
+        # Validate that nested sections are dictionaries
+        for section in ["branding", "layout", "style", "summary"]:
+            if not isinstance(cfg.get(section), dict):
+                raise ConfigurationError(
+                    f"Config section '{section}' must be a dictionary."
+                )
 
-        if summary_cfg["max_chars"] <= 0:
-            raise ValueError("summary.max_chars must be > 0")
-    except ValueError as e:
-        raise ValueError(f"Invalid summary configuration: {e}")
-    except KeyError as e:
-        raise ValueError(f"Missing key in summary configuration: {e}")
-
-    try:
-        palette_cfg = cfg["style"]["palette"]
-        categorical = palette_cfg["categorical"]
-        if not (
-            categorical
-            and isinstance(categorical, list)
-            and all(isinstance(s, str) for s in categorical)
-        ):
-            raise ValueError(
-                "style.palette.categorical must be a non-empty list of strings"
+        if not isinstance(cfg.get("style", {}).get("palette"), dict):
+            raise ConfigurationError(
+                "Config section 'style.palette' must be a dictionary."
             )
-    except KeyError as e:
-        raise ValueError(f"Missing key in style configuration: {e}")
 
-    # --- Dataclass Construction ---
-    try:
+        # Coerce provider string to Enum before passing to constructor
+        summary_cfg = cfg["summary"]
+        summary_cfg["provider"] = Summary.Provider(summary_cfg["provider"])
+
+        # Let dataclass constructors handle the rest.
+        # __post_init__ will run validation.
         return Config(
             title=cfg["title"],
             branding=Branding(**cfg["branding"]),
@@ -153,10 +165,9 @@ def coerce_config(d: dict) -> Config:
             layout=Layout(**cfg["layout"]),
             summary=Summary(**cfg["summary"]),
         )
-    except (TypeError, KeyError) as e:
-        raise ValueError(
-            f"Configuration is missing required fields or has unexpected fields: {e}"
-        )
+    except (ValueError, TypeError, KeyError) as e:
+        # Catch validation errors from __post_init__ or construction errors
+        raise ConfigurationError(f"Invalid configuration: {e}") from e
 
 
 def load_config(settings: dict | None = None) -> Config:

--- a/zn_report/config.py
+++ b/zn_report/config.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, asdict
+from copy import deepcopy
+from dataclasses import asdict, dataclass
+from enum import Enum
 from typing import Any
 
 from zn_report.constants import (
@@ -54,7 +56,9 @@ class Summary:
     class Provider(str, Enum):
         """Providers for summary generation."""
 
+        NONE = "none"
         LOCAL = "local"
+        OPENAI = "openai"
 
     enabled: bool = True
     provider: Provider = Provider.LOCAL
@@ -89,16 +93,80 @@ def to_dict(cfg: Config) -> dict[str, Any]:
     return asdict(cfg)
 
 
-def load_config(path: str) -> dict[str, Any]:
-    """Load the configuration from a YAML file.
+def deep_merge(base: dict, override: dict) -> dict:
+    """Merge two dictionaries recursively.
 
-    Args:
-        path: The path to the YAML configuration file.
-
-    Returns:
-        A dictionary containing the configuration.
+    Lists are replaced, scalars are overwritten, and dicts are merged.
     """
-    # TODO: Implement YAML parsing.
-    # For now, this is a stub that returns an empty dict.
-    print(f"TODO: Load config from {path}")
-    return {}
+    result = deepcopy(base)
+    for key, value in override.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def coerce_config(d: dict) -> Config:
+    """Convert a merged dict into typed dataclasses.
+
+    Raise ValueError on missing/invalid fields.
+    """
+    cfg = deepcopy(d)
+
+    # --- Validation and Coercion ---
+    try:
+        summary_cfg = cfg["summary"]
+        provider_str = summary_cfg["provider"]
+        summary_cfg["provider"] = Summary.Provider(provider_str)
+
+        if summary_cfg["max_chars"] <= 0:
+            raise ValueError("summary.max_chars must be > 0")
+    except ValueError as e:
+        raise ValueError(f"Invalid summary configuration: {e}")
+    except KeyError as e:
+        raise ValueError(f"Missing key in summary configuration: {e}")
+
+    try:
+        palette_cfg = cfg["style"]["palette"]
+        categorical = palette_cfg["categorical"]
+        if not (
+            categorical
+            and isinstance(categorical, list)
+            and all(isinstance(s, str) for s in categorical)
+        ):
+            raise ValueError(
+                "style.palette.categorical must be a non-empty list of strings"
+            )
+    except KeyError as e:
+        raise ValueError(f"Missing key in style configuration: {e}")
+
+    # --- Dataclass Construction ---
+    try:
+        return Config(
+            title=cfg["title"],
+            branding=Branding(**cfg["branding"]),
+            style=Style(
+                palette=Palette(**cfg["style"]["palette"]),
+                font_family=cfg["style"]["font_family"],
+            ),
+            layout=Layout(**cfg["layout"]),
+            summary=Summary(**cfg["summary"]),
+        )
+    except (TypeError, KeyError) as e:
+        raise ValueError(
+            f"Configuration is missing required fields or has unexpected fields: {e}"
+        )
+
+
+def load_config(settings: dict | None = None) -> Config:
+    """If None, return DEFAULT_CONFIG.
+
+    Else, deep_merge(to_dict(DEFAULT_CONFIG), settings) → coerce_config.
+    """
+    if settings is None:
+        return DEFAULT_CONFIG
+
+    base_config = to_dict(DEFAULT_CONFIG)
+    merged_config = deep_merge(base_config, settings)
+    return coerce_config(merged_config)


### PR DESCRIPTION
This commit extends the configuration handling in `zn_report/config.py` by introducing a robust in-memory loading mechanism.

Key changes include:
- A `deep_merge` function for recursively merging dictionaries, allowing for partial overrides of the default configuration.
- A `coerce_config` function that converts a raw dictionary into a typed `Config` dataclass object. This function also performs validation to ensure that configuration values are valid (e.g., `max_chars` is positive, `provider` is a valid enum member, `categorical` is a non-empty list).
- The existing `load_config` stub has been replaced with a new implementation that accepts an optional dictionary of settings. If provided, these settings are merged with the `DEFAULT_CONFIG` and then coerced into a validated `Config` object.
- The `Summary.Provider` enum has been updated to include `none` and `openai` as valid options.