### PR TITLE
Implement header reading and validation for CSV files

### DIFF
--- a/tests/test_io_loader.py
+++ b/tests/test_io_loader.py
@@ -1,0 +1,77 @@
+import os
+import unittest
+import pandas as pd
+import pytest
+
+from zn_report.io_loader import (
+    read_csv_headers,
+    validate_headers,
+    ensure_headers_ok,
+)
+from zn_report.exceptions import MissingHeadersError
+from zn_report.constants import REQUIRED_HEADERS
+
+
+class TestIoLoader(unittest.TestCase):
+    def setUp(self):
+        """Set up test files."""
+        self.test_dir = "test_data"
+        os.makedirs(self.test_dir, exist_ok=True)
+
+        self.valid_headers = sorted(list(REQUIRED_HEADERS))
+        self.missing_headers = self.valid_headers[:-2]
+
+        self.valid_csv_path = os.path.join(self.test_dir, "valid.csv")
+        self.invalid_csv_path = os.path.join(self.test_dir, "invalid.csv")
+        self.empty_csv_path = os.path.join(self.test_dir, "empty.csv")
+
+        pd.DataFrame(columns=self.valid_headers).to_csv(
+            self.valid_csv_path, index=False
+        )
+        pd.DataFrame(columns=self.missing_headers).to_csv(
+            self.invalid_csv_path, index=False
+        )
+        with open(self.empty_csv_path, "w") as f:
+            f.write("")
+
+    def tearDown(self):
+        """Tear down test files."""
+        import shutil
+        shutil.rmtree(self.test_dir)
+
+    def test_read_csv_headers_valid(self):
+        headers = read_csv_headers(self.valid_csv_path)
+        self.assertEqual(headers, self.valid_headers)
+
+    def test_read_csv_headers_invalid(self):
+        headers = read_csv_headers(self.invalid_csv_path)
+        self.assertEqual(headers, self.missing_headers)
+
+    def test_read_csv_headers_empty(self):
+        with self.assertRaises(pd.errors.EmptyDataError):
+            read_csv_headers(self.empty_csv_path)
+
+    def test_validate_headers_valid(self):
+        try:
+            validate_headers(self.valid_headers)
+        except MissingHeadersError:
+            self.fail("validate_headers() raised MissingHeadersError unexpectedly!")
+
+    def test_validate_headers_invalid(self):
+        with pytest.raises(MissingHeadersError) as excinfo:
+            validate_headers(self.missing_headers)
+
+        missing = sorted(list(REQUIRED_HEADERS - set(self.missing_headers)))
+        self.assertEqual(excinfo.value.missing, missing)
+
+    def test_ensure_headers_ok_valid(self):
+        headers = ensure_headers_ok(self.valid_csv_path)
+        self.assertEqual(headers, self.valid_headers)
+
+    def test_ensure_headers_ok_invalid(self):
+        with pytest.raises(MissingHeadersError):
+            ensure_headers_ok(self.invalid_csv_path)
+
+    def test_ensure_headers_ok_file_not_found(self):
+        with self.assertRaises(FileNotFoundError):
+            ensure_headers_ok("non_existent_file.csv")

--- a/tests/test_io_loader.py
+++ b/tests/test_io_loader.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import unittest
 import pandas as pd
 import pytest
@@ -36,7 +37,6 @@ class TestIoLoader(unittest.TestCase):
 
     def tearDown(self):
         """Tear down test files."""
-        import shutil
         shutil.rmtree(self.test_dir)
 
     def test_read_csv_headers_valid(self):
@@ -48,14 +48,11 @@ class TestIoLoader(unittest.TestCase):
         self.assertEqual(headers, self.missing_headers)
 
     def test_read_csv_headers_empty(self):
-        with self.assertRaises(pd.errors.EmptyDataError):
+        with pytest.raises(pd.errors.EmptyDataError):
             read_csv_headers(self.empty_csv_path)
 
     def test_validate_headers_valid(self):
-        try:
-            validate_headers(self.valid_headers)
-        except MissingHeadersError:
-            self.fail("validate_headers() raised MissingHeadersError unexpectedly!")
+        validate_headers(self.valid_headers)
 
     def test_validate_headers_invalid(self):
         with pytest.raises(MissingHeadersError) as excinfo:
@@ -73,5 +70,5 @@ class TestIoLoader(unittest.TestCase):
             ensure_headers_ok(self.invalid_csv_path)
 
     def test_ensure_headers_ok_file_not_found(self):
-        with self.assertRaises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError):
             ensure_headers_ok("non_existent_file.csv")

--- a/zn_report/constants.py
+++ b/zn_report/constants.py
@@ -4,6 +4,21 @@ from __future__ import annotations
 
 DEFAULT_SEED: int = 42
 
+# Data loading
+REQUIRED_HEADERS: frozenset[str] = frozenset(
+    {
+        "sys_tags",
+        "comments",
+        "work_notes",
+        "assigned_to",
+        "opened_at",
+        "state",
+        "resolved_at",
+        "u_original_assignment_group",
+        "close_code",
+    }
+)
+
 # Branding & style defaults
 DEFAULT_TITLE = "Zscaler Incident Report"
 DEFAULT_FONT_FAMILY = "Inter, Arial, sans-serif"

--- a/zn_report/io_loader.py
+++ b/zn_report/io_loader.py
@@ -25,9 +25,9 @@ def validate_headers(headers: list[str]) -> None:
     Raises:
         MissingHeadersError: If any required headers are missing.
     """
-    missing = [h for h in sorted(list(REQUIRED_HEADERS)) if h not in headers]
+    missing = REQUIRED_HEADERS - set(headers)
     if missing:
-        raise MissingHeadersError(missing)
+        raise MissingHeadersError(list(missing))
 
 
 def ensure_headers_ok(path: str, encoding: str = "utf-8") -> list[str]:

--- a/zn_report/io_loader.py
+++ b/zn_report/io_loader.py
@@ -1,23 +1,22 @@
 import pandas as pd
 from typing import Iterator
 
+from zn_report.constants import REQUIRED_HEADERS
 from zn_report.exceptions import MissingHeadersError
-
-REQUIRED_HEADERS: frozenset[str] = frozenset({
-    "sys_tags",
-    "comments",
-    "work_notes",
-    "assigned_to",
-    "opened_at",
-    "state",
-    "resolved_at",
-    "u_original_assignment_group",
-    "close_code",
-})
 
 
 def read_csv_headers(path: str, encoding: str = "utf-8") -> list[str]:
-    ...
+    """Reads only the headers of a CSV file.
+
+    Args:
+        path: The path to the CSV file.
+        encoding: The encoding of the file.
+
+    Returns:
+        A list of header strings.
+    """
+    df = pd.read_csv(path, nrows=0, encoding=encoding)
+    return list(df.columns)
 
 
 def validate_headers(headers: list[str]) -> None:
@@ -26,7 +25,24 @@ def validate_headers(headers: list[str]) -> None:
     Raises:
         MissingHeadersError: If any required headers are missing.
     """
-    ...
+    missing = [h for h in sorted(list(REQUIRED_HEADERS)) if h not in headers]
+    if missing:
+        raise MissingHeadersError(missing)
+
+
+def ensure_headers_ok(path: str, encoding: str = "utf-8") -> list[str]:
+    """Convenience guard that reads headers and validates them.
+
+    Args:
+        path: The path to the CSV file.
+        encoding: The encoding of the file.
+
+    Returns:
+        The list of headers if they are valid.
+    """
+    headers = read_csv_headers(path, encoding)
+    validate_headers(headers)
+    return headers
 
 
 def load_csv(


### PR DESCRIPTION
This commit introduces three new functions to `zn_report.io_loader`:

- `read_csv_headers`: Reads only the headers from a CSV file.
- `validate_headers`: Validates that a list of headers contains all the required headers.
- `ensure_headers_ok`: A convenience function that reads and validates headers from a file path.

The `REQUIRED_HEADERS` constant has been moved to `zn_report.constants` for better organization.

Unit tests have been added to ensure the new functions work as expected.