### PR TITLE
feat: Add _normalize_strings function for data cleaning

### DIFF
--- a/tests/test_io_loader.py
+++ b/tests/test_io_loader.py
@@ -3,8 +3,10 @@ import shutil
 import unittest
 import pandas as pd
 import pytest
+import numpy as np
 
 from zn_report.io_loader import (
+    _normalize_strings,
     read_csv_headers,
     validate_headers,
     ensure_headers_ok,
@@ -72,3 +74,53 @@ class TestIoLoader(unittest.TestCase):
     def test_ensure_headers_ok_file_not_found(self):
         with pytest.raises(FileNotFoundError):
             ensure_headers_ok("non_existent_file.csv")
+
+    def test_normalize_strings(self):
+        """Test the _normalize_strings function."""
+        test_data = {
+            "comments": ["  leading", "trailing  ", "  both  ", "no space"],
+            "work_notes": [" a ", "b", " c", "d "],
+            "assigned_to": ["  test ", "", None, np.nan],
+            "state": ["  New", "Closed  ", " In Progress ", ""],
+            "non_string_col": [1, 2, 3, 4],  # This column should not be affected
+        }
+        input_df = pd.DataFrame(test_data)
+
+        normalized_df = _normalize_strings(input_df)
+
+        # Check that a copy is returned
+        self.assertIsNot(input_df, normalized_df)
+
+        # Check whitespace stripping
+        pd.testing.assert_series_equal(
+            normalized_df["comments"],
+            pd.Series(["leading", "trailing", "both", "no space"], name="comments", dtype="string"),
+        )
+        pd.testing.assert_series_equal(
+            normalized_df["work_notes"],
+            pd.Series(["a", "b", "c", "d"], name="work_notes", dtype="string"),
+        )
+        pd.testing.assert_series_equal(
+            normalized_df["state"],
+            pd.Series(["New", "Closed", "In Progress", ""], name="state", dtype="string"),
+        )
+
+        # Check 'assigned_to' special handling
+        expected_assigned_to = pd.Series(
+            ["test", "Unassigned", "Unassigned", "Unassigned"], name="assigned_to", dtype="string"
+        )
+        pd.testing.assert_series_equal(normalized_df["assigned_to"], expected_assigned_to)
+
+        # Check that columns not in STRING_COLS are untouched
+        self.assertTrue("non_string_col" in normalized_df.columns)
+        self.assertTrue(pd.api.types.is_integer_dtype(normalized_df["non_string_col"]))
+
+        # Test with a DataFrame that has no columns from STRING_COLS
+        no_string_cols_df = pd.DataFrame({"a": [1], "b": [2]})
+        processed_df = _normalize_strings(no_string_cols_df.copy())
+        pd.testing.assert_frame_equal(processed_df, no_string_cols_df)
+
+        # Test with an empty DataFrame
+        empty_df = pd.DataFrame()
+        processed_empty_df = _normalize_strings(empty_df)
+        pd.testing.assert_frame_equal(processed_empty_df, empty_df)

--- a/zn_report/io_loader.py
+++ b/zn_report/io_loader.py
@@ -22,9 +22,8 @@ def _normalize_strings(df: pd.DataFrame) -> pd.DataFrame:
     for col in STRING_COLS:
         if col in df.columns:
             df[col] = df[col].astype(pd.StringDtype()).str.strip()
-
-    if "assigned_to" in df.columns:
-        df["assigned_to"] = df["assigned_to"].replace("", "Unassigned").fillna("Unassigned")
+            if col == "assigned_to":
+                df[col] = df[col].replace("", "Unassigned").fillna("Unassigned")
 
     return df
 

--- a/zn_report/io_loader.py
+++ b/zn_report/io_loader.py
@@ -5,6 +5,30 @@ from zn_report.constants import REQUIRED_HEADERS
 from zn_report.exceptions import MissingHeadersError
 
 
+STRING_COLS = (
+    "sys_tags",
+    "comments",
+    "work_notes",
+    "assigned_to",
+    "state",
+    "u_original_assignment_group",
+    "close_code",
+)
+
+
+def _normalize_strings(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalize string columns."""
+    df = df.copy()
+    for col in STRING_COLS:
+        if col in df.columns:
+            df[col] = df[col].astype(pd.StringDtype()).str.strip()
+
+    if "assigned_to" in df.columns:
+        df["assigned_to"] = df["assigned_to"].replace("", "Unassigned").fillna("Unassigned")
+
+    return df
+
+
 def read_csv_headers(path: str, encoding: str = "utf-8") -> list[str]:
     """Reads only the headers of a CSV file.
 


### PR DESCRIPTION
This commit introduces a new function, `_normalize_strings`, to `zn_report/io_loader.py` for basic string data cleanup.

Key changes:
- A `STRING_COLS` constant has been added to define which columns should be treated as strings.
- The `_normalize_strings` function performs the following actions on a DataFrame:
  - Creates a copy to avoid modifying the original data.
  - For each column in `STRING_COLS`, it converts the column to `pd.StringDtype` and strips leading/trailing whitespace.
  - For the `assigned_to` column, it replaces empty strings and null values with "Unassigned".

This change provides a foundational step for data cleaning at load time, as requested.