### PR TITLE
I've implemented the scaffolding for the new time operations. This ch…

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pandas>=2.0,<3.0
 pytest>=7
+tzdata>=2024.1; sys_platform == "win32"

--- a/tests/test_time_ops.py
+++ b/tests/test_time_ops.py
@@ -1,0 +1,54 @@
+import pandas as pd
+import pytest
+from datetime import date
+from pandas.api.types import is_datetime64tz_dtype
+
+from zn_report.time_ops import parse_dates, derive_buckets
+
+
+def test_parse_dates_localize_and_convert():
+    df = pd.DataFrame({
+        "opened_at": [
+            "2025-03-08 01:30:00",            # naive → localize to America/Chicago
+            "2025-07-03T17:05:00-05:00",      # tz-aware → convert to America/Chicago
+            "bad-date",                        # invalid → NaT
+        ],
+        "resolved_at": [
+            "2025-03-08 03:30:00",
+            "2025-07-03T17:45:00-05:00",
+            ""
+        ],
+        "sys_tags": ["a", "b", "c"]
+    })
+
+    out = parse_dates(df, tz="America/Chicago")
+
+    assert is_datetime64tz_dtype(out["opened_at"])
+    assert is_datetime64tz_dtype(out["resolved_at"])
+
+    # Row 0: naive localized to target tz (date component should match 2025-03-08)
+    assert out.loc[0, "opened_at"].date().isoformat() == "2025-03-08"
+
+    # Row 1: tz-aware converted (date remains 2025-07-03 in target tz)
+    assert out.loc[1, "opened_at"].date().isoformat() == "2025-07-03"
+
+    # Row 2: invalid → NaT
+    assert pd.isna(out.loc[2, "opened_at"])
+
+    # Non-date column untouched
+    assert list(out["sys_tags"]) == ["a", "b", "c"]
+
+
+def test_derive_buckets_inclusive_and_types():
+    # Accepts strings
+    buckets = derive_buckets("2024-02-28", "2024-03-01", tz="UTC")
+    assert buckets == [date(2024,2,28), date(2024,2,29), date(2024,3,1)]
+
+    # Accepts date objects
+    b2 = derive_buckets(date(2025, 7, 1), date(2025, 7, 3), tz="America/Chicago")
+    assert b2 == [date(2025,7,1), date(2025,7,2), date(2025,7,3)]
+
+
+def test_derive_buckets_rejects_inverted_range():
+    with pytest.raises(ValueError):
+        derive_buckets("2025-08-10", "2025-08-09", tz="UTC")

--- a/zn_report/time_ops.py
+++ b/zn_report/time_ops.py
@@ -22,35 +22,25 @@ def parse_dates(df: pd.DataFrame, tz: str) -> pd.DataFrame:
     - Leaves non-date columns untouched.
     """
     out = df.copy()
-    tzinfo = ZoneInfo(tz)
 
-    def _coerce_one(x):
-        if x is None or (isinstance(x, float) and pd.isna(x)) or (isinstance(x, str) and x.strip() == ""):
+    def _process_timestamp(ts):
+        if pd.isna(ts):
             return pd.NaT
-        try:
-            ts = pd.to_datetime(x, errors="raise")
-        except Exception:
-            return pd.NaT
-        # pandas Timestamp: tz-aware → convert; naive → localize
-        if getattr(ts, "tzinfo", None) is None:
-            try:
-                # Handle DST gaps/ambiguous by coercing to NaT rather than raising
-                return ts.tz_localize(tzinfo, nonexistent="NaT", ambiguous="NaT")
-            except TypeError:
-                # Fallback for older pandas without nonexistent/ambiguous kwargs
-                try:
-                    return ts.tz_localize(tzinfo)
-                except Exception:
-                    return pd.NaT
+        if ts.tzinfo is None:
+            return ts.tz_localize(tz, nonexistent="NaT", ambiguous="NaT")
         else:
-            return ts.tz_convert(tzinfo)
+            return ts.tz_convert(tz)
 
     for col in _DATE_COLS:
         if col in out.columns:
-            out[col] = pd.Series((_coerce_one(v) for v in out[col]))
+            # Element-wise conversion is needed to correctly handle mixed naive/aware
+            # strings as per spec (vectorized pd.to_datetime assumes UTC for naive).
+            s = out[col].apply(pd.to_datetime, errors="coerce")
+            # Apply timezone logic to each element.
+            out[col] = s.apply(_process_timestamp)
         else:
-            # Required by spec elsewhere, but we don't enforce header contract here.
-            out[col] = pd.Series([], dtype="datetime64[ns]")
+            # If a date column is missing, create an empty one with the target dtype.
+            out[col] = pd.Series([], dtype=f"datetime64[ns, {tz}]")
 
     return out
 

--- a/zn_report/time_ops.py
+++ b/zn_report/time_ops.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+from datetime import date, datetime, timedelta
+from typing import Iterable, List
+from zoneinfo import ZoneInfo
+import pandas as pd
+
+
+DATE_OPEN = "opened_at"
+DATE_RESOLVED = "resolved_at"
+_DATE_COLS: tuple[str, str] = (DATE_OPEN, DATE_RESOLVED)
+
+
+def parse_dates(df: pd.DataFrame, tz: str) -> pd.DataFrame:
+    """
+    Convert 'opened_at' and 'resolved_at' to tz-aware pandas datetimes in the
+    requested display timezone.
+
+    Rules (spec-aligned):
+    - If a value carries an explicit timezone, convert it to the display TZ.
+    - If a value is naive, localize it **as-is** to the display TZ (no UTC first).
+    - Parse errors → NaT (still compatible with tz-aware dtype).
+    - Leaves non-date columns untouched.
+    """
+    out = df.copy()
+    tzinfo = ZoneInfo(tz)
+
+    def _coerce_one(x):
+        if x is None or (isinstance(x, float) and pd.isna(x)) or (isinstance(x, str) and x.strip() == ""):
+            return pd.NaT
+        try:
+            ts = pd.to_datetime(x, errors="raise")
+        except Exception:
+            return pd.NaT
+        # pandas Timestamp: tz-aware → convert; naive → localize
+        if getattr(ts, "tzinfo", None) is None:
+            try:
+                # Handle DST gaps/ambiguous by coercing to NaT rather than raising
+                return ts.tz_localize(tzinfo, nonexistent="NaT", ambiguous="NaT")
+            except TypeError:
+                # Fallback for older pandas without nonexistent/ambiguous kwargs
+                try:
+                    return ts.tz_localize(tzinfo)
+                except Exception:
+                    return pd.NaT
+        else:
+            return ts.tz_convert(tzinfo)
+
+    for col in _DATE_COLS:
+        if col in out.columns:
+            out[col] = pd.Series((_coerce_one(v) for v in out[col]))
+        else:
+            # Required by spec elsewhere, but we don't enforce header contract here.
+            out[col] = pd.Series([], dtype="datetime64[ns]")
+
+    return out
+
+
+def derive_buckets(start: date | str, end: date | str, tz: str) -> list[date]:
+    """
+    Return an inclusive list of calendar dates from start..end (YYYY-MM-DD window).
+    'tz' is accepted for interface parity; buckets themselves are date-only.
+    """
+    def _to_date(d) -> date:
+        if isinstance(d, date):
+            return d
+        return pd.to_datetime(d, errors="raise").date()
+
+    s = _to_date(start)
+    e = _to_date(end)
+    if s > e:
+        raise ValueError("start date must be <= end date")
+
+    days = (e - s).days + 1
+    return [s + timedelta(days=i) for i in range(days)]


### PR DESCRIPTION
…ange does the following:

- Creates the `zn_report/time_ops.py` module with `parse_dates` and `derive_buckets` functions.
- Adds tests for the new time operations in `tests/test_time_ops.py`.
- Updates `requirements-dev.txt` to include `tzdata` for Windows environments.