### PR TITLE
Refactor: Stricter date parsing in time_ops

### DIFF
--- a/tests/test_time_ops.py
+++ b/tests/test_time_ops.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 from datetime import date
-from pandas.api.types import is_datetime64tz_dtype
+from pandas.api.types import DatetimeTZDtype
 
 from zn_report.time_ops import parse_dates, derive_buckets
 
@@ -23,8 +23,8 @@ def test_parse_dates_localize_and_convert():
 
     out = parse_dates(df, tz="America/Chicago")
 
-    assert is_datetime64tz_dtype(out["opened_at"])
-    assert is_datetime64tz_dtype(out["resolved_at"])
+    assert isinstance(out["opened_at"].dtype, DatetimeTZDtype)
+    assert isinstance(out["resolved_at"].dtype, DatetimeTZDtype)
 
     # Row 0: naive localized to target tz (date component should match 2025-03-08)
     assert out.loc[0, "opened_at"].date().isoformat() == "2025-03-08"
@@ -52,3 +52,22 @@ def test_derive_buckets_inclusive_and_types():
 def test_derive_buckets_rejects_inverted_range():
     with pytest.raises(ValueError):
         derive_buckets("2025-08-10", "2025-08-09", tz="UTC")
+
+
+def test_parse_dates_handles_dst_boundaries():
+    # DST in America/Chicago for 2025:
+    # - Spring forward: Mar 9, 2:00 AM -> 3:00 AM (2:00-2:59 does not exist)
+    # - Fall back: Nov 2, 2:00 AM -> 1:00 AM (1:00-1:59 is ambiguous)
+    df = pd.DataFrame({
+        "opened_at": [
+            "2025-03-09 02:30:00",  # nonexistent time
+            "2025-11-02 01:30:00",  # ambiguous time
+        ],
+    })
+
+    out = parse_dates(df, tz="America/Chicago")
+
+    # Non-existent and ambiguous times should be coerced to NaT
+    assert pd.isna(out.loc[0, "opened_at"])
+    assert pd.isna(out.loc[1, "opened_at"])
+    assert isinstance(out["opened_at"].dtype, DatetimeTZDtype)

--- a/zn_report/time_ops.py
+++ b/zn_report/time_ops.py
@@ -3,6 +3,7 @@ from datetime import date, datetime, timedelta
 from typing import Iterable, List
 from zoneinfo import ZoneInfo
 import pandas as pd
+from pandas.api.types import is_datetime64tz_dtype, DatetimeTZDtype
 
 
 DATE_OPEN = "opened_at"
@@ -22,25 +23,39 @@ def parse_dates(df: pd.DataFrame, tz: str) -> pd.DataFrame:
     - Leaves non-date columns untouched.
     """
     out = df.copy()
+    target_tz = ZoneInfo(tz)
 
-    def _process_timestamp(ts):
-        if pd.isna(ts):
+    def _process_timestamp(value):
+        if pd.isna(value) or value == "":
             return pd.NaT
-        if ts.tzinfo is None:
-            return ts.tz_localize(tz, nonexistent="NaT", ambiguous="NaT")
+        try:
+            # Per spec, parse with errors="raise"
+            ts = pd.to_datetime(value, errors="raise")
+        except (ValueError, TypeError):
+            return pd.NaT
+
+        # If tz-aware, convert to target_tz.
+        if ts.tzinfo is not None:
+            return ts.tz_convert(target_tz)
+        # If naive, localize to target_tz. Coerce DST boundary issues to NaT.
         else:
-            return ts.tz_convert(tz)
+            return ts.tz_localize(target_tz, nonexistent="NaT", ambiguous="NaT")
 
     for col in _DATE_COLS:
         if col in out.columns:
-            # Element-wise conversion is needed to correctly handle mixed naive/aware
-            # strings as per spec (vectorized pd.to_datetime assumes UTC for naive).
-            s = out[col].apply(pd.to_datetime, errors="coerce")
-            # Apply timezone logic to each element.
-            out[col] = s.apply(_process_timestamp)
+            out[col] = out[col].apply(_process_timestamp)
+            # After processing, ensure the column has the correct timezone-aware dtype,
+            # especially if it contains all NaT values (which results in object dtype).
+            if not isinstance(out[col].dtype, DatetimeTZDtype):
+                # This can happen if all inputs were invalid, creating a Series of NaTs
+                # with a non-tz-aware dtype (like object or datetime64[ns]).
+                # We must explicitly convert it to the target tz-aware dtype.
+                # `astype` fails for naive -> aware, so we convert to datetime (if needed),
+                # then localize. Since all values are NaT, localizing is safe.
+                out[col] = pd.to_datetime(out[col]).dt.tz_localize(target_tz)
         else:
             # If a date column is missing, create an empty one with the target dtype.
-            out[col] = pd.Series([], dtype=f"datetime64[ns, {tz}]")
+            out[col] = pd.Series([], dtype=f"datetime64[ns, {target_tz}]")
 
     return out
 

--- a/zn_report/time_ops.py
+++ b/zn_report/time_ops.py
@@ -3,7 +3,7 @@ from datetime import date, datetime, timedelta
 from typing import Iterable, List
 from zoneinfo import ZoneInfo
 import pandas as pd
-from pandas.api.types import is_datetime64tz_dtype, DatetimeTZDtype
+from pandas.api.types import DatetimeTZDtype
 
 
 DATE_OPEN = "opened_at"


### PR DESCRIPTION
Refines the `parse_dates` function to more strictly adhere to the specification for handling timezone-aware and naive datetimes.

- Implements element-wise date parsing using `pd.to_datetime(errors="raise")` within a try-except block to catch and handle invalid date strings by coercing them to NaT.
- For naive timestamps, localizes to the target timezone, correctly handling Daylight Saving Time transitions by coercing non-existent or ambiguous times to NaT.
- For timezone-aware timestamps, converts them to the target timezone.
- Ensures the output columns always have a timezone-aware dtype, even if they contain only NaT values, which prevents dtype issues in downstream operations.
- Adds a new test case to verify the DST handling logic.
- Updates existing tests to use the modern `isinstance(dtype, pd.DatetimeTZDtype)` check.