### PR TITLE
feat(metrics): implement UPT v3 engine

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,152 @@
+import pytest
+import pandas as pd
+from datetime import date
+
+from zn_report.metrics import compute_metrics
+
+@pytest.fixture(scope="module")
+def sample_ticket_df() -> pd.DataFrame:
+    """Provides a comprehensive sample DataFrame for testing metrics."""
+    data = [
+        # 8 tickets resolved within the window (July 15-17)
+        {"opened_at": "2025-07-14 10:00", "resolved_at": "2025-07-15 12:00", "state": "Resolved", "assigned_to": "Alice", "sys_tags": "foo, bar", "close_code": "Solved"},
+        {"opened_at": "2025-07-15 08:00", "resolved_at": "2025-07-16 10:00", "state": "Resolved", "assigned_to": "Bob", "sys_tags": "baz; foo", "close_code": "Solved Remotely"},
+        {"opened_at": "2025-07-16 11:00", "resolved_at": "2025-07-16 14:00", "state": "Resolved", "assigned_to": "Alice", "sys_tags": "FOO|bar", "close_code": "Solved"},
+        {"opened_at": "2025-07-17 09:00", "resolved_at": "2025-07-17 23:50", "state": "Resolved", "assigned_to": "Charlie", "sys_tags": "dup, foo, dup", "close_code": "Not Applicable"},
+        {"opened_at": "2025-07-15 10:00", "resolved_at": "2025-07-15 10:00", "state": "Resolved", "assigned_to": "Bob", "sys_tags": "foo; foo", "close_code": ""}, # Unspecified code
+        {"opened_at": "2025-07-15 10:00", "resolved_at": "2025-07-16 10:00", "state": "Resolved", "assigned_to": "Dave", "sys_tags": "baz", "close_code": "Solved"},
+        {"opened_at": "2025-07-15 10:00", "resolved_at": "2025-07-17 10:00", "state": "Resolved", "assigned_to": "Dave", "sys_tags": "baz", "close_code": "Solved Remotely"},
+        {"opened_at": pd.NaT, "resolved_at": "2025-07-15 10:00", "state": "Resolved", "assigned_to": "Charlie", "sys_tags": "no-open-date", "close_code": "Solved"},
+
+        # 2 tickets resolved outside the window
+        {"opened_at": "2025-07-10 10:00", "resolved_at": "2025-07-14 10:00", "state": "Resolved", "assigned_to": "Bob", "sys_tags": "irrelevant", "close_code": "Solved"},
+        {"opened_at": "2025-07-18 10:00", "resolved_at": "2025-07-19 10:00", "state": "Resolved", "assigned_to": "Alice", "sys_tags": "irrelevant", "close_code": "Solved"},
+
+        # 4 tickets still open (or in a non-open terminal state)
+        {"opened_at": "2025-07-16 10:00", "resolved_at": pd.NaT, "state": "In Progress", "assigned_to": "Bob", "sys_tags": "open", "close_code": pd.NaT},
+        {"opened_at": "2025-07-17 10:00", "resolved_at": pd.NaT, "state": "new", "assigned_to": "Unassigned", "sys_tags": "open, new", "close_code": pd.NaT},
+        {"opened_at": "2025-07-17 12:00", "resolved_at": pd.NaT, "state": "On Hold", "assigned_to": "Alice", "sys_tags": "open, hold", "close_code": pd.NaT},
+        {"opened_at": "2025-07-16 10:00", "resolved_at": pd.NaT, "state": "Closed", "assigned_to": "Unassigned", "sys_tags": "wrong-state", "close_code": pd.NaT},
+    ]
+    return pd.DataFrame(data).astype({"assigned_to": "string", "close_code": "string", "state": "string", "sys_tags": "string"})
+
+@pytest.fixture(scope="module")
+def metrics_results(sample_ticket_df) -> dict:
+    """Provides the results of running compute_metrics on the sample_ticket_df."""
+    return compute_metrics(
+        df=sample_ticket_df.copy(), # Pass a copy to avoid side effects
+        start="2025-07-15",
+        end="2025-07-17",
+        tz="America/New_York"
+    )
+
+def test_envelope_structure(metrics_results: dict):
+    """Tests the top-level structure of the metrics envelope."""
+    assert isinstance(metrics_results, dict)
+    expected_keys = {"version", "metadata", "kpis", "series", "tables"}
+    assert set(metrics_results.keys()) == expected_keys
+    assert metrics_results["version"] == 3
+
+def test_metadata(metrics_results: dict):
+    """Tests the content of the metadata section."""
+    meta = metrics_results["metadata"]
+    assert meta["source_path"] == ""
+    assert meta["tz"] == "America/New_York"
+    assert meta["start"] == "2025-07-15"
+    assert meta["end"] == "2025-07-17"
+    assert meta["calendar_days"] == 3
+    assert meta["export_row_count"] == 14
+    assert meta["warnings"] == ["Reports based on an updated-date window may undercount newly opened tickets."]
+
+def test_metadata_dropped_counts(metrics_results: dict):
+    """Tests the dropped record counts in metadata."""
+    dropped = metrics_results["metadata"]["dropped"]
+    assert dropped["opened_at"] == 1
+    assert dropped["resolved_at"] == 4
+    assert dropped["both"] == 0
+
+def test_kpis(metrics_results: dict):
+    """Tests the calculated KPIs."""
+    kpis = metrics_results["kpis"]
+    assert kpis["resolved_count"] == 8
+    assert kpis["resolved_per_day_avg"] == 2.67  # 8 / 3 rounded
+    # TTR calculated on 7 of 8 resolved tickets (one has no open_at)
+    # Sum = 26+26+3+14.8333+0+24+48 = 141.8333... hours
+    # Mean = 141.8333... / 7 = 20.2619...
+    assert kpis["avg_ttr_hours"] == pytest.approx(20.26190476)
+
+def test_kpis_open_states(metrics_results: dict):
+    """Tests the open-by-state KPI."""
+    open_by_state = metrics_results["kpis"]["open_by_state"]
+    assert open_by_state == {"New": 1, "In Progress": 1, "On Hold": 1}
+
+def test_series_resolved_per_day(metrics_results: dict):
+    """Tests the resolved_per_day time series."""
+    series = metrics_results["series"]["resolved_per_day"]
+    assert series == [
+        {"date": "2025-07-15", "count": 3},
+        {"date": "2025-07-16", "count": 3},
+        {"date": "2025-07-17", "count": 2},
+    ]
+
+def test_table_resolved_by_assignee(metrics_results: dict):
+    """Tests the resolved_by_assignee table for sorting and counts."""
+    table = metrics_results["tables"]["resolved_by_assignee"]
+    # 4 assignees, 2 tickets each. Should be sorted by name.
+    assert len(table) == 4
+    expected_order = ["Alice", "Bob", "Charlie", "Dave"]
+    actual_order = [row["assignee"] for row in table]
+    assert actual_order == expected_order
+    for row in table:
+        assert row["count"] == 2
+
+def test_table_top_5_tags(metrics_results: dict):
+    """Tests the top_5_tags table for parsing, counting, and sorting."""
+    table = metrics_results["tables"]["top_5_tags"]
+    # Expected counts: foo:5, baz:3, bar:2, dup:1, no-open-date:1
+    # Tie break between dup and no-open-date is alphabetical: dup, no-open-date
+    expected_table = [
+        {"tag": "foo", "count": 5},
+        {"tag": "baz", "count": 3},
+        {"tag": "bar", "count": 2},
+        {"tag": "dup", "count": 1},
+        {"tag": "no-open-date", "count": 1},
+    ]
+    # We need to sort the tail of the list to handle the tie-break deterministically
+    # The main function sorts by tag name A-Z for ties.
+    assert table[:3] == expected_table[:3]
+    # Check the tie-break part
+    tail = sorted(table[3:], key=lambda x: x['tag'])
+    assert tail[0]['tag'] == 'dup'
+    assert tail[1]['tag'] == 'no-open-date'
+
+
+def test_table_top_5_resolution_codes(metrics_results: dict):
+    """Tests the top_5_resolution_codes table for NA handling and sorting."""
+    table = metrics_results["tables"]["top_5_resolution_codes"]
+    # Expected: Solved:4, Solved Remotely:2, Not Applicable:1, Unspecified:1
+    assert len(table) == 4 # Only 4 distinct codes
+    expected_head = [
+        {"code": "Solved", "count": 4},
+        {"code": "Solved Remotely", "count": 2},
+    ]
+    assert table[:2] == expected_head
+    # Check tie-break part (count=1)
+    tail = sorted([table[2], table[3]], key=lambda x: x["code"])
+    assert tail == [
+        {"code": "Not Applicable", "count": 1},
+        {"code": "Unspecified", "count": 1},
+    ]
+
+def test_empty_input():
+    """Tests that compute_metrics handles an empty DataFrame gracefully."""
+    empty_df = pd.DataFrame(columns=["opened_at", "resolved_at", "state", "assigned_to", "sys_tags", "close_code"])
+    metrics = compute_metrics(empty_df, "2025-01-01", "2025-01-03", "UTC")
+    assert metrics["kpis"]["resolved_count"] == 0
+    assert metrics["kpis"]["resolved_per_day_avg"] == 0.0
+    assert metrics["kpis"]["avg_ttr_hours"] == 0.0
+    assert len(metrics["series"]["resolved_per_day"]) == 3
+    assert all(d["count"] == 0 for d in metrics["series"]["resolved_per_day"])
+    assert metrics["tables"]["resolved_by_assignee"] == []
+    assert metrics["tables"]["top_5_tags"] == []
+    assert metrics["tables"]["top_5_resolution_codes"] == []

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -103,40 +103,28 @@ def test_table_resolved_by_assignee(metrics_results: dict):
 def test_table_top_5_tags(metrics_results: dict):
     """Tests the top_5_tags table for parsing, counting, and sorting."""
     table = metrics_results["tables"]["top_5_tags"]
-    # Expected counts: foo:5, baz:3, bar:2, dup:1, no-open-date:1
-    # Tie break between dup and no-open-date is alphabetical: dup, no-open-date
-    expected_table = [
+    # Expected order is by count (desc), then tag name (asc) for ties.
+    expected = [
         {"tag": "foo", "count": 5},
         {"tag": "baz", "count": 3},
         {"tag": "bar", "count": 2},
         {"tag": "dup", "count": 1},
         {"tag": "no-open-date", "count": 1},
     ]
-    # We need to sort the tail of the list to handle the tie-break deterministically
-    # The main function sorts by tag name A-Z for ties.
-    assert table[:3] == expected_table[:3]
-    # Check the tie-break part
-    tail = sorted(table[3:], key=lambda x: x['tag'])
-    assert tail[0]['tag'] == 'dup'
-    assert tail[1]['tag'] == 'no-open-date'
+    assert table == expected
 
 
 def test_table_top_5_resolution_codes(metrics_results: dict):
     """Tests the top_5_resolution_codes table for NA handling and sorting."""
     table = metrics_results["tables"]["top_5_resolution_codes"]
-    # Expected: Solved:4, Solved Remotely:2, Not Applicable:1, Unspecified:1
-    assert len(table) == 4 # Only 4 distinct codes
-    expected_head = [
+    # Expected order is by count (desc), then code name (asc) for ties.
+    expected = [
         {"code": "Solved", "count": 4},
         {"code": "Solved Remotely", "count": 2},
-    ]
-    assert table[:2] == expected_head
-    # Check tie-break part (count=1)
-    tail = sorted([table[2], table[3]], key=lambda x: x["code"])
-    assert tail == [
         {"code": "Not Applicable", "count": 1},
         {"code": "Unspecified", "count": 1},
     ]
+    assert table == expected
 
 def test_empty_input():
     """Tests that compute_metrics handles an empty DataFrame gracefully."""

--- a/zn_report/metrics.py
+++ b/zn_report/metrics.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+import re
+from collections import Counter
+from datetime import date
+from typing import Any
+
+import pandas as pd
+
+from zn_report.time_ops import derive_buckets, parse_dates
+
+
+def _get_top_tags(series: pd.Series, n: int) -> list[dict[str, Any]]:
+    """Helper to parse, count, and return top N tags with tie-breaking."""
+    if series.empty or series.isna().all():
+        return []
+
+    def _process_row(tag_string: str) -> list[str]:
+        if pd.isna(tag_string) or not tag_string.strip():
+            return []
+        # Split by delimiters, clean, lowercase, and filter blanks
+        tags = [t.strip().lower() for t in re.split(r"[,;|]", tag_string) if t.strip()]
+        # De-dup per row and return as a sorted list for determinism
+        return sorted(list(set(tags)))
+
+    # Process all rows, explode into a single series of tags, and count them
+    all_tags = series.apply(_process_row).explode().dropna()
+    if all_tags.empty:
+        return []
+
+    counts = Counter(all_tags)
+    # Sort by count (desc), then tag (asc) for tie-breaking
+    sorted_tags = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+
+    # Format for output
+    return [{"tag": tag, "count": count} for tag, count in sorted_tags[:n]]
+
+
+def compute_metrics(df: pd.DataFrame, start: str | date, end: str | date, tz: str) -> dict[str, Any]:
+    """
+    Computes UPT v3 metrics from a DataFrame of ticket data.
+
+    Args:
+        df: Input DataFrame with ticket data.
+        start: The start of the reporting window (inclusive).
+        end: The end of the reporting window (inclusive).
+        tz: The timezone for date operations.
+
+    Returns:
+        A dictionary containing the UPT v3 metrics envelope.
+    """
+    # 1. Initial setup & Date Handling
+    export_row_count = len(df)
+    source_path = ""  # Per spec, to be overwritten by CLI if available
+
+    # Use time_ops to get a clean date range and tz-aware df
+    buckets = derive_buckets(start, end, tz)
+    calendar_days = len(buckets)
+
+    # Convert date columns to tz-aware datetime objects. This is a key step
+    # for all downstream calculations.
+    proc_df = parse_dates(df, tz)
+
+    # 2. Calculate dropped counts
+    # Based on NaT in core date fields AFTER parsing
+    opened_na = proc_df["opened_at"].isna()
+    resolved_na = proc_df["resolved_at"].isna()
+
+    # Using .sum() on boolean Series returns numpy int types; cast to standard int
+    dropped_opened_at = int(opened_na.sum())
+    dropped_resolved_at = int(resolved_na.sum())
+    dropped_both = int((opened_na & resolved_na).sum())
+
+    # 3. Formulate warnings
+    # The UPT v3 spec requires this warning as its methodology, which focuses on
+    # resolved tickets, can undercount tickets that were opened but not resolved
+    # within the same window.
+    warnings = ["Reports based on an updated-date window may undercount newly opened tickets."]
+
+    # 4. Assemble metadata payload
+    # Note: buckets list can be empty if start > end, though upstream logic
+    # should prevent this. Handle gracefully just in case.
+    start_str = str(buckets[0]) if buckets else str(start)
+    end_str = str(buckets[-1]) if buckets else str(end)
+
+    metadata = {
+        "version": 3,
+        "source_path": source_path,
+        "tz": tz,
+        "start": start_str,
+        "end": end_str,
+        "calendar_days": calendar_days,
+        "export_row_count": export_row_count,
+        "dropped": {
+            "opened_at": dropped_opened_at,
+            "resolved_at": dropped_resolved_at,
+            "both": dropped_both,
+        },
+        "warnings": warnings,
+    }
+
+    # 5. Filter data for KPI calculations
+    # The primary filter is for tickets resolved within the reporting window.
+    resolved_df = pd.DataFrame(columns=proc_df.columns)
+    if buckets:
+        # Create tz-aware timestamps for the start and end of the date range
+        start_ts = pd.Timestamp(buckets[0], tz=tz)
+        end_ts = pd.Timestamp(buckets[-1], tz=tz).replace(
+            hour=23, minute=59, second=59, microsecond=999999
+        )
+
+        resolved_mask = proc_df["resolved_at"].between(start_ts, end_ts, inclusive="both")
+        # Drop rows where mask is NA (i.e., resolved_at is NaT)
+        resolved_df = proc_df[resolved_mask.fillna(False)].copy()
+
+    # 6. Calculate KPIs
+    resolved_count = len(resolved_df)
+    resolved_per_day_avg = round(resolved_count / calendar_days, 2) if calendar_days > 0 else 0.0
+
+    # TTR (Time to Resolution) in hours
+    if not resolved_df.empty and "opened_at" in resolved_df:
+        # Ensure both date columns are present before calculating delta
+        ttr_deltas = resolved_df["resolved_at"] - resolved_df["opened_at"]
+        # Convert Timedelta to total hours, then take mean. Result is float.
+        avg_ttr_hours = ttr_deltas.dt.total_seconds().mean() / 3600
+        if pd.isna(avg_ttr_hours):  # Mean of empty or all-NaT series is NaN
+            avg_ttr_hours = 0.0
+    else:
+        avg_ttr_hours = 0.0
+
+    # Open states: count tickets that are NOT resolved yet, by state.
+    # Per spec, this is case-insensitive for a fixed list of states.
+    open_states = ["New", "In Progress", "On Hold"]
+    open_df = proc_df[proc_df["resolved_at"].isna()]
+
+    if "state" in open_df.columns and not open_df.empty:
+        # Normalize state column for case-insensitive matching
+        state_counts = open_df["state"].str.lower().value_counts()
+        open_by_state = {state: int(state_counts.get(state.lower(), 0)) for state in open_states}
+    else:
+        open_by_state = {state: 0 for state in open_states}
+
+    kpis = {
+        "resolved_count": resolved_count,
+        "resolved_per_day_avg": resolved_per_day_avg,
+        "avg_ttr_hours": float(avg_ttr_hours),
+        "open_by_state": open_by_state,
+    }
+
+    # 7. Calculate Time Series data
+    # resolved_per_day: count of tickets resolved on each calendar day in window.
+    if not resolved_df.empty:
+        # Extract the date part of the 'resolved_at' timestamp. .dt.date gives date objects.
+        resolved_dates = resolved_df["resolved_at"].dt.date
+        # Count occurrences of each resolution date.
+        daily_counts = resolved_dates.value_counts().to_dict()
+    else:
+        daily_counts = {}
+
+    # Use the buckets to create a zero-filled series. `buckets` is a list[date].
+    resolved_per_day = [
+        {"date": b.strftime("%Y-%m-%d"), "count": daily_counts.get(b, 0)} for b in buckets
+    ]
+
+    series = {
+        "resolved_per_day": resolved_per_day,
+    }
+
+    # 8. Calculate Tables
+    tables = {}
+    if not resolved_df.empty:
+        # Table: Resolved by Assignee
+        if "assigned_to" in resolved_df.columns:
+            assignee_counts = resolved_df["assigned_to"].value_counts()
+            df_assignees = assignee_counts.reset_index()
+            df_assignees.columns = ["assignee", "count"]
+            # Sort by count (desc), then assignee name (asc) for tie-breaking
+            df_assignees = df_assignees.sort_values(by=["count", "assignee"], ascending=[False, True])
+            tables["resolved_by_assignee"] = [
+                {"assignee": row.assignee, "count": int(row.count)}
+                for row in df_assignees.itertuples()
+            ]
+        else:
+            tables["resolved_by_assignee"] = []
+
+        # Table: Top 5 Tags
+        if "sys_tags" in resolved_df.columns:
+            tables["top_5_tags"] = _get_top_tags(resolved_df["sys_tags"], n=5)
+        else:
+            tables["top_5_tags"] = []
+
+        # Table: Top 5 Resolution Codes
+        if "close_code" in resolved_df.columns:
+            # Per spec, NA/blank close codes are "Unspecified"
+            codes = resolved_df["close_code"].fillna("Unspecified").replace("", "Unspecified")
+            code_counts = codes.value_counts()
+            df_codes = code_counts.reset_index()
+            df_codes.columns = ["code", "count"]
+            # Sort by count (desc), then code (asc) for tie-breaking
+            df_codes = df_codes.sort_values(by=["count", "code"], ascending=[False, True])
+            top_5 = df_codes.head(5)
+            tables["top_5_resolution_codes"] = [
+                {"code": row.code, "count": int(row.count)} for row in top_5.itertuples()
+            ]
+        else:
+            tables["top_5_resolution_codes"] = []
+    else:
+        # If there are no resolved tickets, all tables are empty
+        tables = {
+            "resolved_by_assignee": [],
+            "top_5_tags": [],
+            "top_5_resolution_codes": [],
+        }
+
+    return {
+        "version": 3,
+        "metadata": metadata,
+        "kpis": kpis,
+        "series": series,
+        "tables": tables,
+    }

--- a/zn_report/metrics.py
+++ b/zn_report/metrics.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-from datetime import date
-from typing import Any
-
 import re
 from collections import Counter
 from datetime import date
@@ -87,7 +84,6 @@ def compute_metrics(df: pd.DataFrame, start: str | date, end: str | date, tz: st
     end_str = str(buckets[-1]) if buckets else str(end)
 
     metadata = {
-        "version": 3,
         "source_path": source_path,
         "tz": tz,
         "start": start_str,
@@ -170,50 +166,38 @@ def compute_metrics(df: pd.DataFrame, start: str | date, end: str | date, tz: st
     }
 
     # 8. Calculate Tables
-    tables = {}
+    tables = {
+        "resolved_by_assignee": [],
+        "top_5_tags": [],
+        "top_5_resolution_codes": [],
+    }
     if not resolved_df.empty:
         # Table: Resolved by Assignee
         if "assigned_to" in resolved_df.columns:
             assignee_counts = resolved_df["assigned_to"].value_counts()
             df_assignees = assignee_counts.reset_index()
             df_assignees.columns = ["assignee", "count"]
-            # Sort by count (desc), then assignee name (asc) for tie-breaking
             df_assignees = df_assignees.sort_values(by=["count", "assignee"], ascending=[False, True])
             tables["resolved_by_assignee"] = [
                 {"assignee": row.assignee, "count": int(row.count)}
                 for row in df_assignees.itertuples()
             ]
-        else:
-            tables["resolved_by_assignee"] = []
 
         # Table: Top 5 Tags
         if "sys_tags" in resolved_df.columns:
             tables["top_5_tags"] = _get_top_tags(resolved_df["sys_tags"], n=5)
-        else:
-            tables["top_5_tags"] = []
 
         # Table: Top 5 Resolution Codes
         if "close_code" in resolved_df.columns:
-            # Per spec, NA/blank close codes are "Unspecified"
             codes = resolved_df["close_code"].fillna("Unspecified").replace("", "Unspecified")
             code_counts = codes.value_counts()
             df_codes = code_counts.reset_index()
             df_codes.columns = ["code", "count"]
-            # Sort by count (desc), then code (asc) for tie-breaking
             df_codes = df_codes.sort_values(by=["count", "code"], ascending=[False, True])
             top_5 = df_codes.head(5)
             tables["top_5_resolution_codes"] = [
                 {"code": row.code, "count": int(row.count)} for row in top_5.itertuples()
             ]
-        else:
-            tables["top_5_resolution_codes"] = []
-    else:
-        # If there are no resolved tickets, all tables are empty
-        tables = {
-            "resolved_by_assignee": [],
-            "top_5_tags": [],
-            "top_5_resolution_codes": [],
-        }
 
     return {
         "version": 3,


### PR DESCRIPTION
Implements the `compute_metrics` function in `zn_report/metrics.py` to generate the UPT v3 metrics envelope.

The new function provides a comprehensive set of KPIs, time series, and summary tables based on a given window of ticket data.

Key features include:
- Calculation of resolved ticket counts, averages, and time-to-resolution.
- Generation of zero-filled daily resolution time series.
- Detailed tables for resolution by assignee, top tags, and top resolution codes, with deterministic sorting and tie-breaking.
- Robust handling of missing data, including "Unspecified" mapping for close codes and tracking of dropped records.
- Advanced tag parsing with support for multiple delimiters and per-row de-duplication.

Adds a comprehensive suite of unit tests in `tests/test_metrics.py` to validate all calculations, edge cases, and the overall data structure, achieving high test coverage.