### PR TITLE
feat(metrics): implement full UPT v3 analytics spec

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -9,26 +9,33 @@ def sample_ticket_df() -> pd.DataFrame:
     """Provides a comprehensive sample DataFrame for testing metrics."""
     data = [
         # 8 tickets resolved within the window (July 15-17)
-        {"opened_at": "2025-07-14 10:00", "resolved_at": "2025-07-15 12:00", "state": "Resolved", "assigned_to": "Alice", "sys_tags": "foo, bar", "close_code": "Solved"},
-        {"opened_at": "2025-07-15 08:00", "resolved_at": "2025-07-16 10:00", "state": "Resolved", "assigned_to": "Bob", "sys_tags": "baz; foo", "close_code": "Solved Remotely"},
-        {"opened_at": "2025-07-16 11:00", "resolved_at": "2025-07-16 14:00", "state": "Resolved", "assigned_to": "Alice", "sys_tags": "FOO|bar", "close_code": "Solved"},
-        {"opened_at": "2025-07-17 09:00", "resolved_at": "2025-07-17 23:50", "state": "Resolved", "assigned_to": "Charlie", "sys_tags": "dup, foo, dup", "close_code": "Not Applicable"},
-        {"opened_at": "2025-07-15 10:00", "resolved_at": "2025-07-15 10:00", "state": "Resolved", "assigned_to": "Bob", "sys_tags": "foo; foo", "close_code": ""}, # Unspecified code
-        {"opened_at": "2025-07-15 10:00", "resolved_at": "2025-07-16 10:00", "state": "Resolved", "assigned_to": "Dave", "sys_tags": "baz", "close_code": "Solved"},
-        {"opened_at": "2025-07-15 10:00", "resolved_at": "2025-07-17 10:00", "state": "Resolved", "assigned_to": "Dave", "sys_tags": "baz", "close_code": "Solved Remotely"},
-        {"opened_at": pd.NaT, "resolved_at": "2025-07-15 10:00", "state": "Resolved", "assigned_to": "Charlie", "sys_tags": "no-open-date", "close_code": "Solved"},
+        {"opened_at": "2025-07-14 10:00", "resolved_at": "2025-07-15 12:00", "state": "Resolved", "assigned_to": "Alice", "sys_tags": "foo, bar", "close_code": "Solved", "u_original_assignment_group": "dvn-global-zscaler-operations"},
+        {"opened_at": "2025-07-15 08:00", "resolved_at": "2025-07-16 10:00", "state": "Resolved", "assigned_to": "Bob", "sys_tags": "baz; foo", "close_code": "Solved Remotely", "u_original_assignment_group": "Service Desk"},
+        {"opened_at": "2025-07-16 11:00", "resolved_at": "2025-07-16 14:00", "state": "Resolved", "assigned_to": "Alice", "sys_tags": "FOO|bar", "close_code": "Solved", "u_original_assignment_group": "DVN-Global-Zscaler-Operations"},
+        {"opened_at": "2025-07-17 09:00", "resolved_at": "2025-07-17 23:50", "state": "Resolved", "assigned_to": "Charlie", "sys_tags": "dup, foo, dup", "close_code": "Not Applicable", "u_original_assignment_group": pd.NA},
+        {"opened_at": "2025-07-15 10:00", "resolved_at": "2025-07-15 10:00", "state": "Resolved", "assigned_to": "Bob", "sys_tags": "foo; foo", "close_code": "", "u_original_assignment_group": "Some Other Team"},
+        {"opened_at": "2025-07-15 10:00", "resolved_at": "2025-07-16 10:00", "state": "Resolved", "assigned_to": "Dave", "sys_tags": "baz", "close_code": "Solved", "u_original_assignment_group": "dvn-global-zscaler-operations"},
+        {"opened_at": "2025-07-15 10:00", "resolved_at": "2025-07-17 10:00", "state": "Resolved", "assigned_to": "Dave", "sys_tags": "baz", "close_code": "Solved Remotely", "u_original_assignment_group": ""},
+        {"opened_at": pd.NaT, "resolved_at": "2025-07-15 10:00", "state": "Resolved", "assigned_to": "Charlie", "sys_tags": "no-open-date", "close_code": "Solved", "u_original_assignment_group": "Service Desk"},
 
         # 2 tickets resolved outside the window
-        {"opened_at": "2025-07-10 10:00", "resolved_at": "2025-07-14 10:00", "state": "Resolved", "assigned_to": "Bob", "sys_tags": "irrelevant", "close_code": "Solved"},
-        {"opened_at": "2025-07-18 10:00", "resolved_at": "2025-07-19 10:00", "state": "Resolved", "assigned_to": "Alice", "sys_tags": "irrelevant", "close_code": "Solved"},
+        {"opened_at": "2025-07-10 10:00", "resolved_at": "2025-07-14 10:00", "state": "Resolved", "assigned_to": "Bob", "sys_tags": "irrelevant", "close_code": "Solved", "u_original_assignment_group": "Service Desk"},
+        {"opened_at": "2025-07-18 10:00", "resolved_at": "2025-07-19 10:00", "state": "Resolved", "assigned_to": "Alice", "sys_tags": "irrelevant", "close_code": "Solved", "u_original_assignment_group": "Service Desk"},
 
-        # 4 tickets still open (or in a non-open terminal state)
-        {"opened_at": "2025-07-16 10:00", "resolved_at": pd.NaT, "state": "In Progress", "assigned_to": "Bob", "sys_tags": "open", "close_code": pd.NaT},
-        {"opened_at": "2025-07-17 10:00", "resolved_at": pd.NaT, "state": "new", "assigned_to": "Unassigned", "sys_tags": "open, new", "close_code": pd.NaT},
-        {"opened_at": "2025-07-17 12:00", "resolved_at": pd.NaT, "state": "On Hold", "assigned_to": "Alice", "sys_tags": "open, hold", "close_code": pd.NaT},
-        {"opened_at": "2025-07-16 10:00", "resolved_at": pd.NaT, "state": "Closed", "assigned_to": "Unassigned", "sys_tags": "wrong-state", "close_code": pd.NaT},
+        # 5 tickets still open
+        {"opened_at": "2025-07-16 10:00", "resolved_at": pd.NaT, "state": "In Progress", "assigned_to": "Bob", "sys_tags": "open", "close_code": pd.NaT, "u_original_assignment_group": "Service Desk"},
+        {"opened_at": "2025-07-17 10:00", "resolved_at": pd.NaT, "state": "new", "assigned_to": "Unassigned", "sys_tags": "open, new", "close_code": pd.NaT, "u_original_assignment_group": "Service Desk"},
+        {"opened_at": "2025-07-17 12:00", "resolved_at": pd.NaT, "state": "On Hold", "assigned_to": "Alice", "sys_tags": "open, hold", "close_code": pd.NaT, "u_original_assignment_group": "Service Desk"},
+        {"opened_at": "2025-07-16 10:00", "resolved_at": pd.NaT, "state": "Closed", "assigned_to": "Unassigned", "sys_tags": "wrong-state", "close_code": pd.NaT, "u_original_assignment_group": "Service Desk"},
+        {"opened_at": "2025-07-15 18:00", "resolved_at": pd.NaT, "state": "New", "assigned_to": "Unassigned", "sys_tags": "new, open", "close_code": pd.NaT, "u_original_assignment_group": "Service Desk"},
     ]
-    return pd.DataFrame(data).astype({"assigned_to": "string", "close_code": "string", "state": "string", "sys_tags": "string"})
+    return pd.DataFrame(data).astype({
+        "assigned_to": "string",
+        "close_code": "string",
+        "state": "string",
+        "sys_tags": "string",
+        "u_original_assignment_group": "string",
+    })
 
 @pytest.fixture(scope="module")
 def metrics_results(sample_ticket_df) -> dict:
@@ -55,14 +62,14 @@ def test_metadata(metrics_results: dict):
     assert meta["start"] == "2025-07-15"
     assert meta["end"] == "2025-07-17"
     assert meta["calendar_days"] == 3
-    assert meta["export_row_count"] == 14
+    assert meta["export_row_count"] == 15 # Updated from 14
     assert meta["warnings"] == ["Reports based on an updated-date window may undercount newly opened tickets."]
 
 def test_metadata_dropped_counts(metrics_results: dict):
     """Tests the dropped record counts in metadata."""
     dropped = metrics_results["metadata"]["dropped"]
     assert dropped["opened_at"] == 1
-    assert dropped["resolved_at"] == 4
+    assert dropped["resolved_at"] == 5 # Updated from 4
     assert dropped["both"] == 0
 
 def test_kpis(metrics_results: dict):
@@ -70,15 +77,18 @@ def test_kpis(metrics_results: dict):
     kpis = metrics_results["kpis"]
     assert kpis["resolved_count"] == 8
     assert kpis["resolved_per_day_avg"] == 2.67  # 8 / 3 rounded
-    # TTR calculated on 7 of 8 resolved tickets (one has no open_at)
-    # Sum = 26+26+3+14.8333+0+24+48 = 141.8333... hours
-    # Mean = 141.8333... / 7 = 20.2619...
     assert kpis["avg_ttr_hours"] == pytest.approx(20.26190476)
 
 def test_kpis_open_states(metrics_results: dict):
     """Tests the open-by-state KPI."""
     open_by_state = metrics_results["kpis"]["open_by_state"]
-    assert open_by_state == {"New": 1, "In Progress": 1, "On Hold": 1}
+    # Added one more "New" ticket
+    assert open_by_state == {"New": 2, "In Progress": 1, "On Hold": 1}
+
+def test_kpis_open_by_state_total(metrics_results: dict):
+    """Tests the new open_by_state_total KPI."""
+    kpis = metrics_results["kpis"]
+    assert kpis["open_by_state_total"] == 4 # 2 + 1 + 1
 
 def test_series_resolved_per_day(metrics_results: dict):
     """Tests the resolved_per_day time series."""
@@ -89,10 +99,26 @@ def test_series_resolved_per_day(metrics_results: dict):
         {"date": "2025-07-17", "count": 2},
     ]
 
+def test_series_daily_opened(metrics_results: dict):
+    """Tests the new daily_opened time series."""
+    series = metrics_results["series"]["daily_opened"]
+    # Opened dates: 07-15 (5), 07-16 (3), 07-17 (3)
+    assert series == [
+        {"date": "2025-07-15", "count": 5},
+        {"date": "2025-07-16", "count": 3},
+        {"date": "2025-07-17", "count": 3},
+    ]
+
+def test_series_opened_vs_resolved(metrics_results: dict):
+    """Tests the new opened_vs_resolved series."""
+    series = metrics_results["series"]["opened_vs_resolved"]
+    assert series["dates"] == ["2025-07-15", "2025-07-16", "2025-07-17"]
+    assert series["opened"] == [5, 3, 3]
+    assert series["resolved"] == [3, 3, 2]
+
 def test_table_resolved_by_assignee(metrics_results: dict):
     """Tests the resolved_by_assignee table for sorting and counts."""
     table = metrics_results["tables"]["resolved_by_assignee"]
-    # 4 assignees, 2 tickets each. Should be sorted by name.
     assert len(table) == 4
     expected_order = ["Alice", "Bob", "Charlie", "Dave"]
     actual_order = [row["assignee"] for row in table]
@@ -103,7 +129,6 @@ def test_table_resolved_by_assignee(metrics_results: dict):
 def test_table_top_5_tags(metrics_results: dict):
     """Tests the top_5_tags table for parsing, counting, and sorting."""
     table = metrics_results["tables"]["top_5_tags"]
-    # Expected order is by count (desc), then tag name (asc) for ties.
     expected = [
         {"tag": "foo", "count": 5},
         {"tag": "baz", "count": 3},
@@ -113,11 +138,9 @@ def test_table_top_5_tags(metrics_results: dict):
     ]
     assert table == expected
 
-
 def test_table_top_5_resolution_codes(metrics_results: dict):
     """Tests the top_5_resolution_codes table for NA handling and sorting."""
     table = metrics_results["tables"]["top_5_resolution_codes"]
-    # Expected order is by count (desc), then code name (asc) for ties.
     expected = [
         {"code": "Solved", "count": 4},
         {"code": "Solved Remotely", "count": 2},
@@ -126,15 +149,52 @@ def test_table_top_5_resolution_codes(metrics_results: dict):
     ]
     assert table == expected
 
+def test_table_open_by_state(metrics_results: dict):
+    """Tests the new open_by_state table."""
+    table = metrics_results["tables"]["open_by_state"]
+    # Sorted alphabetically by state
+    expected = [
+        {"state": "In Progress", "count": 1},
+        {"state": "New", "count": 2},
+        {"state": "On Hold", "count": 1},
+    ]
+    assert table == expected
+
+def test_table_queue_origin(metrics_results: dict):
+    """Tests the new queue_origin table for categorization and sorting."""
+    table = metrics_results["tables"]["queue_origin"]
+    # Sorted by count (desc), then origin (asc)
+    # DVN-Global-Zscaler-Operations: 3
+    # From Service Desk: 5
+    expected = [
+        {"origin": "From Service Desk", "count": 5},
+        {"origin": "DVN-Global-Zscaler-Operations", "count": 3},
+    ]
+    assert table == expected
+
 def test_empty_input():
     """Tests that compute_metrics handles an empty DataFrame gracefully."""
-    empty_df = pd.DataFrame(columns=["opened_at", "resolved_at", "state", "assigned_to", "sys_tags", "close_code"])
+    empty_df = pd.DataFrame(columns=[
+        "opened_at", "resolved_at", "state", "assigned_to", "sys_tags",
+        "close_code", "u_original_assignment_group"
+    ])
     metrics = compute_metrics(empty_df, "2025-01-01", "2025-01-03", "UTC")
+
     assert metrics["kpis"]["resolved_count"] == 0
     assert metrics["kpis"]["resolved_per_day_avg"] == 0.0
     assert metrics["kpis"]["avg_ttr_hours"] == 0.0
+    assert metrics["kpis"]["open_by_state_total"] == 0
+    assert metrics["kpis"]["open_by_state"] == {"New": 0, "In Progress": 0, "On Hold": 0}
+
     assert len(metrics["series"]["resolved_per_day"]) == 3
     assert all(d["count"] == 0 for d in metrics["series"]["resolved_per_day"])
+    assert len(metrics["series"]["daily_opened"]) == 3
+    assert all(d["count"] == 0 for d in metrics["series"]["daily_opened"])
+    assert metrics["series"]["opened_vs_resolved"]["opened"] == [0, 0, 0]
+    assert metrics["series"]["opened_vs_resolved"]["resolved"] == [0, 0, 0]
+
     assert metrics["tables"]["resolved_by_assignee"] == []
     assert metrics["tables"]["top_5_tags"] == []
     assert metrics["tables"]["top_5_resolution_codes"] == []
+    assert metrics["tables"]["open_by_state"] == []
+    assert metrics["tables"]["queue_origin"] == []

--- a/zn_report/metrics.py
+++ b/zn_report/metrics.py
@@ -101,6 +101,8 @@ def compute_metrics(df: pd.DataFrame, start: str | date, end: str | date, tz: st
     # 5. Filter data for KPI calculations
     # The primary filter is for tickets resolved within the reporting window.
     resolved_df = pd.DataFrame(columns=proc_df.columns)
+    start_ts = None
+    end_ts = None
     if buckets:
         # Create tz-aware timestamps for the start and end of the date range
         start_ts = pd.Timestamp(buckets[0], tz=tz)
@@ -139,37 +141,70 @@ def compute_metrics(df: pd.DataFrame, start: str | date, end: str | date, tz: st
     else:
         open_by_state = {state: 0 for state in open_states}
 
+    open_by_state_total = sum(open_by_state.values())
+
     kpis = {
         "resolved_count": resolved_count,
         "resolved_per_day_avg": resolved_per_day_avg,
         "avg_ttr_hours": float(avg_ttr_hours),
         "open_by_state": open_by_state,
+        "open_by_state_total": open_by_state_total,
     }
 
     # 7. Calculate Time Series data
     # resolved_per_day: count of tickets resolved on each calendar day in window.
     if not resolved_df.empty:
-        # Extract the date part of the 'resolved_at' timestamp. .dt.date gives date objects.
         resolved_dates = resolved_df["resolved_at"].dt.date
-        # Count occurrences of each resolution date.
-        daily_counts = resolved_dates.value_counts().to_dict()
+        resolved_daily_counts = resolved_dates.value_counts().to_dict()
     else:
-        daily_counts = {}
+        resolved_daily_counts = {}
 
-    # Use the buckets to create a zero-filled series. `buckets` is a list[date].
     resolved_per_day = [
-        {"date": b.strftime("%Y-%m-%d"), "count": daily_counts.get(b, 0)} for b in buckets
+        {"date": b.strftime("%Y-%m-%d"), "count": resolved_daily_counts.get(b, 0)} for b in buckets
     ]
+
+    # daily_opened: count of tickets opened on each calendar day in window
+    opened_df_in_window = pd.DataFrame(columns=proc_df.columns)
+    if start_ts and end_ts:
+        opened_mask = proc_df["opened_at"].between(start_ts, end_ts, inclusive="both")
+        opened_df_in_window = proc_df[opened_mask.fillna(False)].copy()
+
+    if not opened_df_in_window.empty:
+        opened_dates = opened_df_in_window["opened_at"].dt.date
+        opened_daily_counts = opened_dates.value_counts().to_dict()
+    else:
+        opened_daily_counts = {}
+
+    daily_opened = [
+        {"date": b.strftime("%Y-%m-%d"), "count": opened_daily_counts.get(b, 0)} for b in buckets
+    ]
+
+    # opened_vs_resolved: combination of daily opened and resolved counts
+    opened_vs_resolved = {
+        "dates": [b.strftime("%Y-%m-%d") for b in buckets],
+        "opened": [d["count"] for d in daily_opened],
+        "resolved": [d["count"] for d in resolved_per_day],
+    }
 
     series = {
         "resolved_per_day": resolved_per_day,
+        "daily_opened": daily_opened,
+        "opened_vs_resolved": opened_vs_resolved,
     }
 
     # 8. Calculate Tables
+    # Table: open_by_state
+    open_by_state_table = [
+        {"state": state, "count": count} for state, count in sorted(open_by_state.items())
+        if count > 0
+    ]
+
     tables = {
         "resolved_by_assignee": [],
         "top_5_tags": [],
         "top_5_resolution_codes": [],
+        "open_by_state": open_by_state_table,
+        "queue_origin": [],
     }
     if not resolved_df.empty:
         # Table: Resolved by Assignee
@@ -197,6 +232,26 @@ def compute_metrics(df: pd.DataFrame, start: str | date, end: str | date, tz: st
             top_5 = df_codes.head(5)
             tables["top_5_resolution_codes"] = [
                 {"code": row.code, "count": int(row.count)} for row in top_5.itertuples()
+            ]
+
+        # Table: Queue Origin
+        if "u_original_assignment_group" in resolved_df.columns:
+            # Create a temporary column for categorization
+            resolved_df["origin"] = resolved_df["u_original_assignment_group"].apply(
+                lambda x: "DVN-Global-Zscaler-Operations"
+                if pd.notna(x) and x.lower() == "dvn-global-zscaler-operations"
+                else "From Service Desk"
+            )
+
+            origin_counts = resolved_df["origin"].value_counts().reset_index()
+            origin_counts.columns = ["origin", "count"]
+            # Sort by count (desc), then origin (asc)
+            origin_counts = origin_counts.sort_values(
+                by=["count", "origin"], ascending=[False, True]
+            )
+            tables["queue_origin"] = [
+                {"origin": row.origin, "count": int(row.count)}
+                for row in origin_counts.itertuples()
             ]
 
     return {


### PR DESCRIPTION
This commit updates the `compute_metrics` function in `zn_report/metrics.py` to fully align with the UPT v3 specification.

New analytics added:
- KPIs: `open_by_state_total`
- Series: `daily_opened`, `opened_vs_resolved`
- Tables: `open_by_state`, `queue_origin`

The `top_5_tags` calculation is confirmed to use the resolved tickets DataFrame (`resolved_df`) for consistency.

All new outputs adhere to the list-of-dictionaries format.

Tests in `tests/test_metrics.py` have been updated and expanded to provide full coverage for the new metrics, including checks for calculations, sorting, and edge cases.

All tests pass successfully.