### PR TITLE
feat(cli): Make auto-date detection the default

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,6 +64,39 @@ def test_cli_invalid_date_range():
     )
 
 
+def test_cli_auto_dates_is_default(tmp_path):
+    """Test a successful run with the default auto-date behavior."""
+    output_pdf = tmp_path / "report.pdf"
+    args = [
+        "--csv",
+        str(VALID_CSV),
+        "--out",
+        str(output_pdf),
+    ]
+
+    result = run_cli(args)
+
+    assert result.returncode == 0
+    assert output_pdf.exists()
+    assert "Auto-detected date range: 2025-07-15 to 2025-07-17" in result.stdout
+    assert "Metrics: resolved=2" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["--csv", str(VALID_CSV), "--start", "2025-07-01"],
+        ["--csv", str(VALID_CSV), "--end", "2025-07-31"],
+    ],
+)
+def test_cli_partial_dates_fail(args):
+    """Test that the CLI fails if only one of two date arguments is provided."""
+    result = run_cli(args)
+
+    assert result.returncode == 2
+    assert "Both --start and --end must be provided" in result.stdout
+
+
 def test_cli_csv_not_found():
     """Test that the CLI exits with code 5 if the CSV file is not found."""
     non_existent_csv = "non_existent_file.csv"
@@ -135,10 +168,6 @@ def test_cli_render_failure(monkeypatch, caplog):
             "zn-report",
             "--csv",
             str(VALID_CSV),
-            "--start",
-            "2025-07-01",
-            "--end",
-            "2025-07-31",
         ],
     )
 
@@ -175,10 +204,6 @@ def test_cli_io_error_during_processing(monkeypatch, caplog):
             "zn-report",
             "--csv",
             str(VALID_CSV),  # File exists, but will fail during read
-            "--start",
-            "2025-07-01",
-            "--end",
-            "2025-07-31",
         ],
     )
 

--- a/zn_report/cli.py
+++ b/zn_report/cli.py
@@ -200,7 +200,7 @@ def cli_main():
                     raise InvalidArgumentsError(
                         f"Start date ({args.start}) cannot be after end date ({args.end})."
                     )
-            except (ValueError, TypeError):
+            except ValueError:
                 raise InvalidArgumentsError(
                     "Invalid date format. Please use YYYY-MM-DD."
                 )

--- a/zn_report/cli.py
+++ b/zn_report/cli.py
@@ -35,12 +35,8 @@ def _parse_args():
     parser.add_argument(
         "--csv", required=True, help="Path to the input ServiceNow CSV export."
     )
-    parser.add_argument(
-        "--start", required=True, help="The report start date (YYYY-MM-DD)."
-    )
-    parser.add_argument(
-        "--end", required=True, help="The report end date (YYYY-MM-DD)."
-    )
+    parser.add_argument("--start", help="The report start date (YYYY-MM-DD).")
+    parser.add_argument("--end", help="The report end date (YYYY-MM-DD).")
     parser.add_argument(
         "--out", default="./report.pdf", help="Path to the output report file."
     )
@@ -116,9 +112,15 @@ def run_report_workflow(args):
     logger.info(f"Loaded {len(df)} rows; tz={args.tz}")
 
     # 3. Time Operations
-    start_date = datetime.strptime(args.start, "%Y-%m-%d").date()
-    end_date = datetime.strptime(args.end, "%Y-%m-%d").date()
     df = time_ops.parse_dates(df, tz=args.tz)
+    if args.start and args.end:
+        start_date = datetime.strptime(args.start, "%Y-%m-%d").date()
+        end_date = datetime.strptime(args.end, "%Y-%m-%d").date()
+    else:
+        start_date = df["opened_at"].min().date()
+        end_date = df["opened_at"].max().date()
+        logger.info(f"Auto-detected date range: {start_date} to {end_date}")
+
     if df["opened_at"].isna().all():
         raise AllRowsDroppedError()
 
@@ -176,15 +178,23 @@ def cli_main():
 
     try:
         # --- Argument Validation ---
-        try:
-            start_date = datetime.strptime(args.start, "%Y-%m-%d").date()
-            end_date = datetime.strptime(args.end, "%Y-%m-%d").date()
-            if start_date > end_date:
+        if (args.start and not args.end) or (args.end and not args.start):
+            raise InvalidArgumentsError(
+                "Both --start and --end must be provided for manual date ranges."
+            )
+
+        if args.start and args.end:
+            try:
+                start_date = datetime.strptime(args.start, "%Y-%m-%d").date()
+                end_date = datetime.strptime(args.end, "%Y-%m-%d").date()
+                if start_date > end_date:
+                    raise InvalidArgumentsError(
+                        f"Start date ({args.start}) cannot be after end date ({args.end})."
+                    )
+            except (ValueError, TypeError):
                 raise InvalidArgumentsError(
-                    f"Start date ({args.start}) cannot be after end date ({args.end})."
+                    "Invalid date format. Please use YYYY-MM-DD."
                 )
-        except ValueError:
-            raise InvalidArgumentsError("Invalid date format. Please use YYYY-MM-DD.")
 
         # --- Run Core Workflow ---
         run_report_workflow(args)

--- a/zn_report/cli.py
+++ b/zn_report/cli.py
@@ -123,7 +123,16 @@ def run_report_workflow(args):
 
     if df["opened_at"].isna().all():
         raise AllRowsDroppedError()
-
+        # Validate DataFrame is not empty and has at least one valid 'opened_at' value
+        if df.empty or df["opened_at"].isna().all():
+            raise AllRowsDroppedError()
+        start_val = df["opened_at"].min()
+        end_val = df["opened_at"].max()
+        if pd.isna(start_val) or pd.isna(end_val):
+            raise AllRowsDroppedError()
+        start_date = start_val.date()
+        end_date = end_val.date()
+        logger.info(f"Auto-detected date range: {start_date} to {end_date}")
     # 4. Metrics Computation
     computed_metrics = metrics.compute_metrics(df, start_date, end_date, tz=args.tz)
     dropped = computed_metrics["metadata"]["dropped"]


### PR DESCRIPTION
This change refactors the date argument handling to make automatic date range detection the default behavior.

- The `--auto-dates` flag has been removed.
- The tool now automatically derives the date range from the data if no date arguments are provided.
- If `--start` and `--end` are provided, they are used for a manual date range.
- Validation is added to ensure both `--start` and `--end` are provided together.
- Tests have been updated to reflect the new default behavior.